### PR TITLE
Maximum tilt up/down angle

### DIFF
--- a/example1.js
+++ b/example1.js
@@ -53,6 +53,9 @@ function upload() {
 				// Display the navigation bar
 				navbar: true,
 
+				// Set max tilt angle
+				tiltUpMax: 40,
+			
 				// Resize the panorama
 				size: {
 						width: '100%',

--- a/example1.js
+++ b/example1.js
@@ -54,7 +54,7 @@ function upload() {
 				navbar: true,
 
 				// Set max tilt angle
-				tiltUpMax: 40,
+				tilt_up_max: 40,
 			
 				// Resize the panorama
 				size: {

--- a/photo-sphere-viewer.js
+++ b/photo-sphere-viewer.js
@@ -41,8 +41,8 @@
  * - navbar_style (Object) (optional) ({}) Style of the navigation bar
  * - loading_img (string) (optional) (null) Loading image URL or path (absolute or relative)
  * - size (Object) (optional) (null) Final size of the panorama container (e.g. {width: 500, height: 300})
- * - tilt_up_max (integer) (optional) (90) The maximum tilt up angle between 0 and 90
- * - tilt_down_max (integer) (optional) (90) The maximum tilt down angle between 0 and 90
+ * - tilt_up_max (number) (optional) (90) The maximum tilt up angle between 0 and 90
+ * - tilt_down_max (number) (optional) (90) The maximum tilt down angle between 0 and 90
  **/
 
 var PhotoSphereViewer = function(args) {

--- a/photo-sphere-viewer.js
+++ b/photo-sphere-viewer.js
@@ -91,6 +91,21 @@ var PhotoSphereViewer = function(args) {
 		return Math.max(min, Math.min(max, x));
 	}
 
+	 /**
+     * Set maximum up and down angle
+     * @param phi
+     * @returns phi
+     */
+	 
+    var setTiltAngle = function (phi){
+        if (phi > TILT_UP_MAX) {
+            phi = TILT_UP_MAX;
+        } else if (phi < TILT_DOWN_MAX) {
+            phi = TILT_DOWN_MAX;
+        }
+        return phi;
+    };
+
 	/**
 	 * Starts to load the panorama
 	 * @return (void)
@@ -558,7 +573,7 @@ var PhotoSphereViewer = function(args) {
 			theta -= Math.floor(theta / (2.0 * Math.PI)) * 2.0 * Math.PI;
 			phi += (y - mouse_y) * PSV_LAT_OFFSET;
 			phi = stayBetween(phi, -Math.PI / 2.0, Math.PI / 2.0)
-
+			phi = setTiltAngle(phi);
 			mouse_x = x;
 			mouse_y = y;
 			render();
@@ -814,6 +829,10 @@ var PhotoSphereViewer = function(args) {
 	// Minimal and maximal fields of view in degrees
 	var PSV_FOV_MIN = (args.min_fov !== undefined) ? stayBetween(parseFloat(args.min_fov), 1, 179) : 30;
 	var PSV_FOV_MAX = (args.max_fov !== undefined) ? stayBetween(parseFloat(args.max_fov), 1, 179) : 90;
+	
+	// Maximum tilt up / down angle
+    var TILT_UP_MAX = (args.tiltUpMax !== undefined) ? (Math.PI / 180) * args.tiltUpMax : Math.PI/2.0;
+    var TILT_DOWN_MAX = (args.tiltDownMax !== undefined) ? -(Math.PI / 180) * args.tiltDownMax : -Math.PI/2.0; 
 
 	// Animation constants
 	var PSV_FRAMES_PER_SECOND = 60;

--- a/photo-sphere-viewer.js
+++ b/photo-sphere-viewer.js
@@ -41,6 +41,8 @@
  * - navbar_style (Object) (optional) ({}) Style of the navigation bar
  * - loading_img (string) (optional) (null) Loading image URL or path (absolute or relative)
  * - size (Object) (optional) (null) Final size of the panorama container (e.g. {width: 500, height: 300})
+ * - tilt_up_max (integer) (optional) (90) The maximum tilt up angle between 0 and 90
+ * - tilt_down_max (integer) (optional) (90) The maximum tilt down angle between 0 and 90
  **/
 
 var PhotoSphereViewer = function(args) {
@@ -92,7 +94,7 @@ var PhotoSphereViewer = function(args) {
 	}
 
 	 /**
-     * Set maximum up and down angle
+     * Set maximum tilt up and down angle
      * @param phi
      * @returns phi
      */
@@ -831,8 +833,8 @@ var PhotoSphereViewer = function(args) {
 	var PSV_FOV_MAX = (args.max_fov !== undefined) ? stayBetween(parseFloat(args.max_fov), 1, 179) : 90;
 	
 	// Maximum tilt up / down angle
-    var TILT_UP_MAX = (args.tiltUpMax !== undefined) ? (Math.PI / 180) * args.tiltUpMax : Math.PI/2.0;
-    var TILT_DOWN_MAX = (args.tiltDownMax !== undefined) ? -(Math.PI / 180) * args.tiltDownMax : -Math.PI/2.0; 
+    var TILT_UP_MAX = (args.tilt_up_max !== undefined) ? (Math.PI / 180) * args.tilt_up_max : Math.PI/2.0;
+    var TILT_DOWN_MAX = (args.tilt_down_max !== undefined) ? -(Math.PI / 180) * args.tilt_down_max : -Math.PI/2.0; 
 
 	// Animation constants
 	var PSV_FRAMES_PER_SECOND = 60;


### PR DESCRIPTION
I use the Photo Sphere Viewer for my project. It is pretty cool and works well. I added an option for setting up the maximum tilt up/down angle because some of the pictures have black holes at the top and the bottom.

Two optional parameters I added are 'tilt_up_max' and 'tilt_down_max'. Each parameter has default value 90 which allows to tilt 90 degrees up/down from the equator of the sphere. The value should be a number between 0 and 90. 

Black hole at the top: 
![pano_black_hole](https://cloud.githubusercontent.com/assets/11968029/7183099/ad44d06a-e412-11e4-9cbd-fbf66feb10f5.png)

Black hole at the bottom: 
![pano_black_hole2](https://cloud.githubusercontent.com/assets/11968029/7183128/e1079b08-e412-11e4-917e-1641201bd408.png)