### PR TITLE
Allows usage of different RDF-Versions

### DIFF
--- a/src/PhotoSphereViewer.js
+++ b/src/PhotoSphereViewer.js
@@ -267,6 +267,10 @@ var PhotoSphereViewer = function(args) {
 
 	var getAttribute = function(data, attr) {
 		var a = data.indexOf('GPano:' + attr) + attr.length + 8, b = data.indexOf('"', a);
+		if (b == -1) {
+			// XML-Metadata
+			a = data.indexOf('GPano:' + attr) + attr.length + 7, b = data.indexOf('<', a);
+		}
 		return data.substring(a, b);
 	};
 


### PR DESCRIPTION
Different cameras store the RDF-Metadata in different ways. There seem to be two ways to store RDF-Data by either specivying the value in an attribute or by adding a text-node. Currently only the attribute-type is supported and this Commit allows usage of the Text-node-tpe.

The text-node is for example used by the Theta-Camera by Ricoh

This addresses the same issue as #13 in a slightly less intrusive way. 

The changes are only applied to the src-Folder as I imagine there is a build-chain that creates the minified and unminified files from that.

It would be great to have these informations in a CONTRIBUTING-file to be able to reproduce that for testing purposes. :wink: