### PR TITLE
Fix the (weird and ugly) Chrome and IE behaviors

### DIFF
--- a/photo-sphere-viewer.js
+++ b/photo-sphere-viewer.js
@@ -1361,12 +1361,22 @@ var PhotoSphereViewer = function(args) {
 
 			container.style.width = '100%';
 			container.style.height = '100%';
+			
+			container.style.top = '0';          // fix-2
+			container.style.left = '0';         // fix-2
+			container.style.margin = '0';       // fix-2
+
 			fitToContainer();
 		}
 
 		else if (!!container.webkitRequestFullscreen || !!container.msRequestFullscreen) {
 			container.style.width = real_viewer_size.width;
 			container.style.height = real_viewer_size.height;
+			
+			container.style.top = '';          // fix-2
+			container.style.left = '';         // fix-2
+			container.style.margin = '';       // fix-2
+
 			fitToContainer();
 		}
 


### PR DESCRIPTION
In some cases Chrome and IE in fullscreen mode move container to inherited position from non-fullscreen mode.
This fix tested in IE 11.0.34, FF 48.0.2, Chrome 52.